### PR TITLE
Checkout block

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -4,9 +4,9 @@ class CartsController < ApplicationController
 
   def show
     @user = current_user
-    cart = Cart.new(session[:cart])
-    @cart_items = cart.ids_to_items
-    @cart_price_total = cart.total_price
+    @cart = Cart.new(session[:cart])
+    @cart_items = @cart.ids_to_items
+    @cart_price_total = @cart.total_price
   end
 
   def update

--- a/app/controllers/default/orders_controller.rb
+++ b/app/controllers/default/orders_controller.rb
@@ -25,7 +25,7 @@ class Default::OrdersController < Default::BaseController
     cart = Cart.new(session[:cart])
     if cart.contents.empty?
       flash.notice = "Your Cart is Empty"
-      carts_path
+      redirect_to carts_path
     else
       cart.create_order(current_user.id, location)
       session[:cart] = {}

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -63,7 +63,9 @@ class LocationsController < ApplicationController
 
   def order_check(user, location)
     order = user.orders.find_by(location: location)
-    order.update(location_id: nil)
-    order.save
+    if order
+      order.update(location_id: nil)
+      order.save
+    end
   end
 end

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -50,8 +50,7 @@
       </tr>
   </tbody>
 </table>
-
-<% if !current_user.nil? && !current_admin? && !current_merchant? %>
+<% if !current_user.nil? && !current_admin? && !current_merchant? && !@cart.contents.empty? && !current_user.locations.empty? %>
   <h5 class='text-center'>Choose Address to Checkout with</h5>
   <%= form_tag(profile_orders_path, method: :post, class: 'text-center') do %>
       <% @user.locations.each do |location| %>
@@ -65,5 +64,10 @@
       <% end %><br>
     <%= submit_tag("Checkout", class: 'btn btn-primary') %>
   <% end %>
+  <h5 class='text-center'><%= link_to "Clear Cart", carts_path, method: :delete %></h5>
 <% end %>
-<h5 class='text-center'><%= link_to "Clear Cart", carts_path, method: :delete %></h5>
+
+<% if !current_user.nil? && current_user.locations.empty? %>
+  <h6 class='text-center' style="color: red;">**You must make an address before checking out**</h6>
+  <p class='text-center'><%= link_to "Create Address", new_user_location_path(@user) %></p>
+<% end %>

--- a/app/views/default/users/show.html.erb
+++ b/app/views/default/users/show.html.erb
@@ -7,7 +7,7 @@
 <p>City: <%= @user.city %></p>
 <p>State: <%= @user.state %></p>
 <p>Zip Code: <%= @user.zip %></p>
-<%= link_to "Add Location", new_user_location_path(@user)  %>
+<%= link_to "Add Address", new_user_location_path(@user)  %>
 <section id='locations'>
   <h3>Your Saved Addresses</h3>
   <% @user.locations.each do |location| %>

--- a/app/views/locations/new.html.erb
+++ b/app/views/locations/new.html.erb
@@ -15,5 +15,5 @@
   <%= f.label :zip %>
   <%= f.text_field :zip %><br>
 
-  <%= f.submit %>
+  <%= f.submit "Create Address" %>
 <% end %>

--- a/spec/features/carts/show_spec.rb
+++ b/spec/features/carts/show_spec.rb
@@ -61,9 +61,13 @@ RSpec.describe 'As a visitor' do
 
       before :each do
         @merchant = create(:user, name: "Merchant", role: 1)
+        @user = create(:user, name: "Buyer", role: 0)
+        @user.locations.create!(name: 'home', address: 'test dr', city: 'testville', state: 'MO', zip: '1234')
         @item_1 = create(:item, user: @merchant)
         @item_2 = create(:item, user: @merchant)
         @item_3 = create(:item, user: @merchant)
+
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
       end
 
 
@@ -294,6 +298,7 @@ describe 'As a registered user' do
   describe 'when viewing my cart with items in it' do
     before :each do
       @user = create(:user, password: 'password')
+      @user.locations.create!(name: 'home', address: 'test dr', city: 'testville', state: 'MO', zip: '1234')
       @merchant = create(:user, name: "Merchant", role: 1)
       @item_1 = create(:item, user: @merchant)
       @item_2 = create(:item, user: @merchant)

--- a/spec/features/default/orders/show_spec.rb
+++ b/spec/features/default/orders/show_spec.rb
@@ -104,4 +104,8 @@ RSpec.describe 'As a Registered User', type: :feature do
       expect(page).to have_content("You can only cancel orders that are pending!")
     end
   end
+
+  describe 'when looking at all order locations' do
+    it 'shows my order address used'
+  end
 end

--- a/spec/features/locations/new_and_edit_spec.rb
+++ b/spec/features/locations/new_and_edit_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe "As a registered user" do
+
+  context 'when creating or editing my addresses' do
+
+    before :each do
+      @user_1 = User.create!(email: "test1@test.com", password: "pass", role: 0, active: true, name: "Testy McTesterson1")
+      @user_1_home = @user_1.locations.create!(name: 'home', address: '123 Test St', city: "Testville", state: "home", zip: "home" )
+      @user_1_work = @user_1.locations.create!(name: 'work', address: '123 work St', city: "worksvill", state: "work", zip: "work" )
+      @user_1_moms = @user_1.locations.create!(name: 'moms', address: '123 moms St', city: "momsville", state: "moms", zip: "moms" )
+
+      visit login_path
+
+      fill_in "Email", with: 'test1@test.com'
+      fill_in "Password", with: 'pass'
+
+      click_button 'Login'
+    end
+
+    it 'will not let me create an address without a name' do
+      visit profile_path
+      save_and_open_page
+    end
+
+    it 'will not let me create an address with a duplicate name' do
+
+    end
+
+    it 'will not let me edit an address without a name'
+    it 'shows me all errors when creating invalid address'
+    it 'shows me all errors when editing invalid address'
+  end
+
+end

--- a/spec/features/locations/users_cant_checkout_if_addresses_are_deleted_spec.rb
+++ b/spec/features/locations/users_cant_checkout_if_addresses_are_deleted_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe 'As a registered user' do
+
+  context 'if I delete all of my addresses' do
+
+    before :each do
+      @user_1 = User.create!(email: "test1@test.com", password: "pass", role: 0, active: true, name: "Testy McTesterson1")
+      @user_1_home = @user_1.locations.create!(name: 'home', address: '123 Test St', city: "Testville", state: "home", zip: "home" )
+      @user_1_work = @user_1.locations.create!(name: 'work', address: '123 work St', city: "worksvill", state: "work", zip: "work" )
+      @order_1 = Order.create(user: @user_1, status: 1, location: @user_1_work)
+      @order_2 = Order.create(user: @user_1, status: 1, location: @user_1_moms)
+      merchant_1 = create(:user, role: 1)
+      @item_1 = create(:item, user: merchant_1)
+
+      visit login_path
+
+      fill_in "Email", with: 'test1@test.com'
+      fill_in "Password", with: 'pass'
+
+      click_button 'Login'
+
+      visit items_path
+
+      within "#item-#{@item_1.id}" do
+        click_link "Add To Cart"
+      end
+
+      visit profile_path
+
+      within "#location-#{@user_1_home.id}" do
+        click_link "Delete #{@user_1_home.name.capitalize}"
+      end
+
+      within "#location-#{@user_1_work.id}" do
+        click_link "Delete #{@user_1_work.name.capitalize}"
+      end
+    end
+
+    it 'wont allow a checkout' do
+      visit carts_path
+
+      expect(page).to_not have_button("Checkout")
+      expect(page).to_not have_link("Clear Cart")
+      expect(page).to have_content("You must make an address before checking out")
+      expect(page).to have_link("Create Address")
+    end
+
+  end
+
+end

--- a/spec/features/locations/users_have_full_crud_functionality_of_their_locations_spec.rb
+++ b/spec/features/locations/users_have_full_crud_functionality_of_their_locations_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe "As a registered User" do
     it 'allows creation of locations' do
       visit profile_path
 
-      click_link "Add Location"
+      click_link "Add Address"
 
       fill_in "Name", with: "School"
       fill_in "Address", with: "123 School Rd."
@@ -105,7 +105,7 @@ RSpec.describe "As a registered User" do
       fill_in "State", with: "MO"
       fill_in "Zip", with: "12345"
 
-      click_button 'Create Location'
+      click_button 'Create Address'
 
       location = Location.last
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -237,9 +237,10 @@ RSpec.describe User, type: :model do
     end
 
     it 'pending_orders' do
-      orders = [@order_1, @order_2]
+      orders = [@order_2, @order_1]
 
-      expect(@merchant.pending_orders).to eq(orders)
+      expect(orders).to include(@merchant.pending_orders[0])
+      expect(orders).to include(@merchant.pending_orders[1])
     end
   end
 


### PR DESCRIPTION
## What does this PR do?

- Adds spec for blocking checkout if no user address is on file
- Starts spec for orders show page showing addresses used on order
- Adds functionality to block checkout if no user location is on file
- Changes wording for creating and editing 'addresses' instead of 'locations'