### PR TITLE
Bug fix 1

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -16,11 +16,13 @@ class CartsController < ApplicationController
     cart = session[:cart]
     if request == "remove_item"
       cart.delete(item_id)
+      coupon_check
     elsif request == "add_one"
       cart[item_id] += 1
     elsif request == "remove_one"
       cart[item_id] -= 1
       cart.delete(item_id) if cart[item_id] == 0
+      coupon_check
     end
 
     redirect_to carts_path
@@ -42,6 +44,17 @@ class CartsController < ApplicationController
   end
 
   private
+
+  def coupon_check
+    if session[:coupon_id]
+      cart = Cart.new(session[:cart])
+      coupon = Coupon.find(session[:coupon_id])
+      merchant_ids = cart.ids_to_items.keys.map{|item| item.user_id}.uniq
+      if !merchant_ids.include?(coupon.user_id)
+        session[:coupon_id] = nil
+      end
+    end
+  end
 
   def cart_user?
     render file: "/public/404" unless !current_admin? && !current_merchant?

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -61,8 +61,7 @@
 </table>
 <% if !current_user.nil? && !current_admin? && !current_merchant? && !@cart.contents.empty? && !current_user.locations.empty? %>
   <%= form_tag coupon_path, class: 'text-center' do %>
-    <p><%= label_tag :code, "Coupon Code" %></p>
-    <p><%= text_field_tag :code %></p>
+    <p><%= text_field_tag :code, nil, placeholder: "COUPON CODE" %></p>
     <p><%= submit_tag "Add Coupon" %></p>
   <% end %>
   <h5 class='text-center'>Choose Address to Checkout with</h5>

--- a/spec/features/coupons/add_spec.rb
+++ b/spec/features/coupons/add_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'As a registered user while viewing my cart' do
 
     visit carts_path
 
-    fill_in "Coupon Code", with: "5OFF"
+    fill_in "code", with: "5OFF"
     click_button "Add Coupon"
 
     expect(current_path).to eq(carts_path)
@@ -46,7 +46,7 @@ RSpec.describe 'As a registered user while viewing my cart' do
 
     visit carts_path
 
-    fill_in "Coupon Code", with: "some"
+    fill_in "code", with: "some"
     click_button "Add Coupon"
 
     expect(current_path).to eq(carts_path)
@@ -61,10 +61,10 @@ RSpec.describe 'As a registered user while viewing my cart' do
 
     visit carts_path
 
-    fill_in "Coupon Code", with: "2OFF"
+    fill_in "code", with: "2OFF"
     click_button "Add Coupon"
 
-    fill_in "Coupon Code", with: "5OFF"
+    fill_in "code", with: "5OFF"
     click_button "Add Coupon"
 
     expect(current_path).to eq(carts_path)
@@ -81,7 +81,7 @@ RSpec.describe 'As a registered user while viewing my cart' do
 
     visit carts_path
 
-    fill_in "Coupon Code", with: "5OFF"
+    fill_in "code", with: "5OFF"
     click_button "Add Coupon"
 
     expect(page).to have_content("Invalid Coupon")


### PR DESCRIPTION
## What does this PR do?

- Changes coupon entry to not show label and instead have a faded placeholder
- Adds check for coupons before removing items from cart to also remove coupon
- Changes cart feature spec to account for coupon entry not having a label