### PR TITLE
Coupon edit fix

### DIFF
--- a/app/controllers/merchants/coupons_controller.rb
+++ b/app/controllers/merchants/coupons_controller.rb
@@ -28,6 +28,7 @@ class Merchants::CouponsController < Merchants::BaseController
   end
 
   def update
+    @user = current_user
     @coupon = Coupon.find(params[:id])
     @coupon.update(coupon_params)
     if @coupon.save

--- a/spec/features/merchants/coupons/edit_spec.rb
+++ b/spec/features/merchants/coupons/edit_spec.rb
@@ -74,4 +74,18 @@ RSpec.describe 'As a merchant viewing my coupons' do
     expect(page).to_not have_content(@two_off.code)
   end
 
+  it 'cant create coupon with string as amount' do
+
+    within "#coupon-#{@two_off.id}" do
+      click_link "Edit #{@two_off.name}"
+    end
+
+    fill_in "Amount off", with: "dsgs"
+
+    click_button "Update Coupon"
+
+    expect(current_path).to eq(dashboard_coupon_path(@two_off))
+    expect(page).to have_content("Amount off is not a number")
+  end
+
 end


### PR DESCRIPTION
## What does this PR do?

- Adds test to throw error if editing coupons amount off with string
- Adds current user call to ivar in merchants coupons edit action to render edit form correctly