### PR TITLE
Fix merchant order show page to show only the location the order was …

### DIFF
--- a/app/views/merchants/orders/show.html.erb
+++ b/app/views/merchants/orders/show.html.erb
@@ -1,9 +1,7 @@
 <h2>Order <%= @order.id %></h2>
 
 <p>Name: <%= @user.name %></p>
-<% @user.locations.each do |location| %>
-  <p>Address <%= location.name.capitalize %>: <%= location.address %>, <%= location.city %>, <%= location.state %>, <%= location.zip %> </p>
-<% end %>
+<p>Order Location: <%= @order.location.address %>, <%= @order.location.city %>, <%= @order.location.state %>, <%= @order.location.zip %> </p>
 
 
 <% if @order.coupon %>

--- a/spec/features/merchants/orders/show_spec.rb
+++ b/spec/features/merchants/orders/show_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'As a merchant', type: :feature do
   describe 'When I visit an order show page from my Dasboard' do
     before :each do
       @user = User.create!(email: "test@test.com", password_digest: "t3s7", role: 1, active: true, name: "Testy McTesterson")
-      @user.locations.create!(name: 'home', address: '123 Test St',state: 'Testville', city: 'Test', zip: '01234')
+      @user_location = @user.locations.create!(name: 'home', address: '123 Test St',state: 'Testville', city: 'Test', zip: '01234')
 
       @merchant_1 = create(:user, role: 1)
       @merchant_2 = create(:user, role: 1)
@@ -13,7 +13,7 @@ RSpec.describe 'As a merchant', type: :feature do
       @item_2 = create(:item, user: @merchant_1)
       @item_3 = create(:item, user: @merchant_2)
 
-      @order = create(:order, user: @user)
+      @order = create(:order, user: @user, location: @user_location)
 
       @order_item_1 = create(:order_item, order: @order, item: @item_1)
       @order_item_2 = create(:order_item, order: @order, item: @item_2)
@@ -26,7 +26,7 @@ RSpec.describe 'As a merchant', type: :feature do
       visit dashboard_order_path(@order)
 
       expect(page).to have_content("Name: Testy McTesterson")
-      expect(page).to have_content("Address Home: 123 Test St, Test, Testville, 01234")
+      expect(page).to have_content("Order Location: 123 Test St, Test, Testville, 01234")
     end
 
     it 'Displays only my Items in the Order' do


### PR DESCRIPTION
…created with

## What does this PR do?

- Fixes merchant order show page to show only the users location that was created with the order